### PR TITLE
Fixed draw_subghz.py

### DIFF
--- a/scripts/fff/draw_subghz.py
+++ b/scripts/fff/draw_subghz.py
@@ -27,10 +27,7 @@ for line in lines:
 # Split the data into a list of individual timings
 timings = []
 for line in data:
-  timings.append(line.split())
-
-# Convert the list of lists into a single list of numbers
-timings = [int(x) for x in timings[0]]
+  timings.extend((int(x) for x in line.split()))
 
 # Convert timings to a stream of 0s and 1s
 stream = []


### PR DESCRIPTION
The previous version had a bug that made it drew only the first "Raw_Data" line's data points

Here is a simple test case file:
```
Filetype: Flipper SubGhz RAW File
Version: 1
Frequency: 433920000
Preset: FuriHalSubGhzPresetOok650Async
Protocol: RAW
RAW_Data: 10 -10
RAW_Data: 20 -20
```